### PR TITLE
changed role names ImagingLambdaExecutionRole, BedrockKBExecutionRole…

### DIFF
--- a/agent_build.yaml
+++ b/agent_build.yaml
@@ -1482,7 +1482,7 @@ Resources:
   ImagingLambdaExecutionRole:
     Type: AWS::IAM::Role
     Properties:
-      RoleName: ImagingBiomarkerLambdaExecutionRole
+      RoleName: !Sub 'ImagingBiomarkerLambdaExecutionRole-${AWS::Region}'
       AssumeRolePolicyDocument:
         Version: '2012-10-17'
         Statement:
@@ -1804,7 +1804,7 @@ Resources:
   BedrockKBExecutionRole:
     Type: 'AWS::IAM::Role'
     Properties:
-      RoleName: !Sub 'AmazonBedrockExecutionRoleForKnowledgeBase_${EnvironmentName}'
+      RoleName: !Sub 'AmazonBedrockExecutionRoleForKnowledgeBase_${EnvironmentName}_${AWS::Region}'
       AssumeRolePolicyDocument:
         Version: '2012-10-17'
         Statement:

--- a/streamlitapp/streamlit_build.yaml
+++ b/streamlitapp/streamlit_build.yaml
@@ -46,7 +46,7 @@ Resources:
     Type: "AWS::IAM::ManagedPolicy"
     Properties:
       Path: /
-      ManagedPolicyName: !Sub "LogsPolicy${EnvironmentName}"
+      ManagedPolicyName: !Sub "LogsPolicy${EnvironmentName}${AWS::Region}"
       PolicyDocument:
         Version: '2012-10-17'
         Statement:


### PR DESCRIPTION
… and LogsPolicy(streamlit_build.yaml)

*Issue #, if available:*

*Description of changes:*
Main repo code in the deployement stage was throwing error when trying to deploy the prohect in us-east-1 and us-west-2 region at the same time due to same role namings. Changed the role naming to fix the issue

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
