### PR TITLE
replaced deprecated redshift cluster nodes

### DIFF
--- a/Infra_cfn.yaml
+++ b/Infra_cfn.yaml
@@ -74,7 +74,7 @@ Resources:
     Properties:
       DBName: !Ref RedshiftDatabaseName
       ClusterIdentifier: biomarker-redshift-cluster
-      NodeType: dc2.large
+      NodeType: ra3.large
       MasterUsername: !Ref RedshiftUserName
       MasterUserPassword: !Ref RedshiftPassword
       ClusterType: single-node


### PR DESCRIPTION
*Issue #123 

*Description of changes:*

replaced deprecated rc2 node type with ra3 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
