### PR TITLE
Update deprecated Claude models and Python version in HCLS AgentCore Builder

### DIFF
--- a/agentcore_template/README.md
+++ b/agentcore_template/README.md
@@ -43,11 +43,11 @@
 3. **Bedrock Model Access**: Enable access to Amazon Bedrock Anthropic Claude models in your AWS region
    - Navigate to [Amazon Bedrock](https://console.aws.amazon.com/bedrock/)
    - Go to "Model access" and request access to:
-     - Anthropic Claude 3.7 Sonnet model
-     - Anthropic Claude 3.5 Haiku model
+     - Anthropic Claude 4.5 Sonnet model
+     - Anthropic Claude 4.5 Haiku model
    - [Bedrock Model Access Guide](https://docs.aws.amazon.com/bedrock/latest/userguide/model-access.html)
 
-4. **Python 3.10+**: Required for running the application
+4. **Python 3.11+**: Required for running the application
    - [Python Downloads](https://www.python.org/downloads/)
 
 ## Deploy

--- a/agentcore_template/prerequisite/docs-rag/README.md
+++ b/agentcore_template/prerequisite/docs-rag/README.md
@@ -41,11 +41,11 @@ This is a template for creating AI agents using Amazon Bedrock AgentCore framewo
 3. **Bedrock Model Access**: Enable access to Amazon Bedrock Anthropic Claude models in your AWS region
    - Navigate to [Amazon Bedrock](https://console.aws.amazon.com/bedrock/)
    - Go to "Model access" and request access to:
-     - Anthropic Claude 3.5 Sonnet model
-     - Anthropic Claude 3.5 Haiku model
+     - Anthropic Claude 4.5 Sonnet model
+     - Anthropic Claude 4.5 Haiku model
    - [Bedrock Model Access Guide](https://docs.aws.amazon.com/bedrock/latest/userguide/model-access.html)
 
-4. **Python 3.10+**: Required for running the application
+4. **Python 3.11+**: Required for running the application
    - [Python Downloads](https://www.python.org/downloads/)
 
 ## Deploy

--- a/powers/hcls-agentcore-builder/POWER.md
+++ b/powers/hcls-agentcore-builder/POWER.md
@@ -71,11 +71,11 @@ These files provide comprehensive context about the repository structure, techno
 **AWS Setup:**
 - AWS account with appropriate permissions
 - AWS CLI configured with credentials
-- Access to Amazon Bedrock (Claude 3.7 Sonnet or later)
+- Access to Amazon Bedrock (Claude 4.5 Sonnet or later)
 - IAM roles for AgentCore services
 
 **Development Environment:**
-- Python 3.10+ installed
+- Python 3.11+ installed
 - `uv` package manager (preferred) or `pip`
 - Git for version control
 
@@ -89,7 +89,7 @@ These files provide comprehensive context about the repository structure, techno
 
 ```bash
 # Verify Python version
-python --version  # Should be 3.10+
+python --version  # Should be 3.11+
 
 # Verify AWS CLI
 aws --version

--- a/powers/hcls-agentcore-builder/README.md
+++ b/powers/hcls-agentcore-builder/README.md
@@ -86,7 +86,7 @@ Read steering file: tech.md (technology stack)
 
 Users of this power should have:
 - AWS account with Bedrock access
-- Python 3.10+
+- Python 3.11+
 - AWS CLI configured
 - Basic understanding of AWS services
 - Familiarity with Python and REST APIs

--- a/powers/hcls-agentcore-builder/steering/tech.md
+++ b/powers/hcls-agentcore-builder/steering/tech.md
@@ -18,7 +18,7 @@
 
 ## Languages & Runtimes
 
-- **Python 3.10+**: Primary language for agents and backend
+- **Python 3.11+**: Primary language for agents and backend
 - **Node.js/TypeScript**: For React UI components
 - **Shell Scripts**: Deployment and automation (bash/zsh)
 


### PR DESCRIPTION
## Summary

Update deprecated model references and Python version requirements across the HCLS AgentCore Builder power and agentcore_template documentation.

## Urgency

| Item | Status | Urgency | Action |
|------|--------|---------|--------|
| Claude 3.7 Sonnet EOL (yesterday) | 🔴 | **Immediate** | Migrate to `claude-sonnet-4-20250514` or `claude-sonnet-4-5-20250514` |
| Claude 3.5 Haiku EOL June 19 | 🟡 | ~7 weeks | Migrate to Claude Haiku 4.5 |
| Python 3.10 Lambda Deprecation Oct 31 | 🟢 | ~6 months | Upgrade to `python3.12` or `python3.13` (AL2023) |

## Changes

### Claude Model Updates (deprecated → current)
- Claude 3.7 Sonnet → **Claude 4.5 Sonnet** (`claude-sonnet-4-5-20250514`)
- Claude 3.5 Sonnet → **Claude 4.5 Sonnet** (`claude-sonnet-4-5-20250514`)
- Claude 3.5 Haiku → **Claude 4.5 Haiku**

### Python Version Update
- Python 3.10+ → **Python 3.11+**

## Files Modified (5 files, 11 line changes)
- `powers/hcls-agentcore-builder/POWER.md` — model + Python version
- `powers/hcls-agentcore-builder/README.md` — Python version
- `powers/hcls-agentcore-builder/steering/tech.md` — Python version
- `agentcore_template/README.md` — model + Python version
- `agentcore_template/prerequisite/docs-rag/README.md` — model + Python version

## Note
There are additional Claude 3.5 references in ~15 agent READMEs across `agents_catalog/` that are outside the scope of this PR but should be addressed in a follow-up.

## Testing
- Documentation-only changes, no code affected
- Verified no remaining references to deprecated versions in modified files