### PR TITLE
Proposal: HCLS Agents Toolkit positioning and transformation roadmap

### DIFF
--- a/docs/proposals/decision-log-and-rationale.md
+++ b/docs/proposals/decision-log-and-rationale.md
@@ -1,0 +1,186 @@
+# Decision Log: HCLS Agents Toolkit Transformation
+
+## The Bigger "Why"
+
+The market is shifting. Customers are asking: **"Are you building industry-specific modules for Amazon Q Desktop?"** and expecting AI-powered domain solutions that non-technical users can access without deploying infrastructure.
+
+Simultaneously, the AI coding assistant landscape (Claude Code, Kiro, Codex, Cursor) is converging on a standard extensibility model: **skills (knowledge) + MCP servers (actions) + plugins (packaging)**. This model is now shared — with variations in format — across developer tools AND end-user platforms (Claude Co-work, Amazon Q Desktop).
+
+The HCLS Agents Toolkit has a catalog of 36+ production-ready agents, but they're currently **only accessible as deployed runtimes**. A researcher can't use them without an AWS deployment. A developer can't discover them without reading READMEs. A clinician can't reach them without a custom UI.
+
+**The transformation makes the same HCLS domain capabilities accessible across four consumption paths — without rebuilding anything from scratch.** The catalog agents remain the production product. We add a portable interface layer (skills + MCP tools) that makes those capabilities consumable by coding assistants and end-user platforms directly.
+
+---
+
+## Questions We Explored and Decisions Reached
+
+### Q1: How does the Agent Catalog fit within a plugin-like toolkit setup?
+
+**Options considered:**
+- A) Catalog as "recipes" that skills know how to cook
+- B) Catalog as composable building blocks for multi-agent workflows
+- C) Catalog as the showcase, skills as the on-ramp
+- D) Catalog agents become skill references (domain knowledge extracted from agent code)
+
+**Decision:** A combination, but primarily **C (catalog is the product, skills are the on-ramp) with elements of D (skills extract domain knowledge from agents).**
+
+**Why:** The catalog is the existing investment and the production offering. Skills don't replace agents — they make agents more discoverable and their domain knowledge more portable. An agent's system prompt, tool logic, and workflow patterns contain valuable domain knowledge that can be extracted as a skill for developer/user consumption.
+
+---
+
+### Q2: If I have skills and MCP servers, why do I need custom agents at all?
+
+**Answer:** You need deployed agents when you need:
+- Non-technical end-users (they won't use an IDE)
+- Compliance/audit trails (HIPAA requires fixed guardrails, not a chat session)
+- Scale (1000 concurrent users)
+- Determinism (pinned model version, tested tool subset)
+- Cost optimization (right-sized model per task)
+- System integration (EHR, event-driven pipelines)
+
+**Decision:** Skills + MCP servers serve exploration and development. Deployed catalog agents serve production. Same capabilities, different packaging for different contexts.
+
+**Why:** A researcher exploring "what biomarkers exist for NSCLC" doesn't need a deployed agent — they need a Q Desktop session connected to the Biomni Gateway. But a hospital system running clinical decision support for 10,000 patients/day needs a production agent with guardrails, audit logs, and SLAs.
+
+---
+
+### Q3: Are we duplicating capabilities between MCP servers and catalog agents?
+
+**Options considered:**
+- A) MCP servers as thin proxies over deployed agent Gateway tools (no duplication, but requires deployment)
+- B) Shared tool library with two entry points (MCP server + agent both import from same code)
+- C) MCP servers ARE the canonical tools, agents consume them via Gateway
+
+**Decision:** **Option A for short term, converging toward C long term.** The current architecture already supports this — AgentCore Gateway IS an MCP server. Agent 28 already demonstrates this pattern.
+
+**Why:** Agent 28's Biomni Gateway is already an MCP endpoint. Any MCP client (Q Desktop, Co-work, another agent) can connect to it. We don't need to build separate MCP servers — the deployed Gateway tools ARE the MCP tools. The "thin proxy" is already built into AgentCore.
+
+---
+
+### Q4: Should the HCLS Toolkit also expose itself as a plugin (like the AWS Agent Toolkit)?
+
+**Decision:** Yes. Same plugin format, registered as a separate marketplace.
+
+**Why:** Builders should be able to `install aws-agents` (how to build on AWS) AND `install hcls-agents` (what to build for HCLS). Composable, not competing.
+
+---
+
+### Q5: Can our plugin support multiple AI coding assistants?
+
+**Research findings:**
+
+| Surface | Skill format | MCP support | Distribution |
+|---------|-------------|-------------|--------------|
+| Claude Code | `.claude-plugin/` + SKILL.md | `.mcp.json` (stdio) | Git marketplace |
+| Claude Co-work | SKILL.md with frontmatter | App UI config (stdio + HTTP) | Plugin registry |
+| Amazon Q Desktop | SKILL.md in `~/.quickwork/skills/` | Settings → Capabilities (stdio + SSE) | Manual file + server |
+| Kiro | POWER.md + steering/ | `mcp.json` in power dir | Local path |
+| Codex | `.codex-plugin/` + SKILL.md | Similar to Claude Code | Git-based |
+
+**Decision:** Build skills as SKILL.md (shared content), package with thin adapters per surface. MCP servers are already universally portable.
+
+**Why:** The CONTENT is portable. A well-written SKILL.md works across all surfaces with minor frontmatter adjustments. MCP servers work everywhere with zero adaptation. Only the distribution packaging differs — and that's a thin wrapper.
+
+---
+
+### Q6: What about non-technical users accessing HCLS workflows through Q Desktop / Co-work?
+
+**Key insight from platform research:**
+- Both Q Desktop and Co-work support MCP servers
+- Both support SKILL.md-style workflow guidance
+- Neither has enterprise admin-push (yet)
+- Both expose custom tools to users via natural language — no coding required
+
+**Decision:** The HCLS Toolkit should produce MCP-accessible domain tools (deployed to AgentCore) that end-user platforms can connect to directly. This answers the market question about "industry-specific modules."
+
+**Why:** A researcher in Q Desktop who connects to the HCLS Biomni Gateway gets 30+ biomedical database tools accessible via natural language. No agent deployment needed on their end. The Gateway IS the industry module.
+
+---
+
+### Q7: Should we focus on the "product" (catalog) or the "developer experience" (plugins)?
+
+**Decision:** Both, but cleanly separated.
+
+**Why:** They serve different audiences and have different lifecycles:
+- Product (catalog) = what gets deployed to production, serves end-users
+- Developer experience (plugin) = what helps builders create/customize/deploy agents faster
+
+The plugin references the catalog but doesn't duplicate it. The catalog benefits from the plugin's skills but doesn't depend on them.
+
+---
+
+### Q8: What's the relationship between this effort and the ongoing v1→v2 migration?
+
+**Decision:** Complementary, not dependent. Short and medium term work proceeds without waiting for migration. Long-term full decomposition depends on agents being on v2.
+
+**Why:** 
+- Skills can be written against the target v2 architecture now (they're knowledge, not code)
+- MCP configs can reference already-deployed v2 agents (28, 35, 36)
+- As migration delivers more v2 agents, each immediately gains a skill + MCP endpoint
+- The two workstreams have natural handoff: migration delivers the agent, this roadmap delivers the portable interface
+
+---
+
+### Q9: How do multi-agent workflows get assembled?
+
+**Options considered:**
+- A) Hardcoded supervisor agents (like the existing cancer biomarker discovery supervisor)
+- B) Static workflow configs (Step Functions, DAGs)
+- C) Dynamic orchestration via AgentCore Registry semantic search
+
+**Decision:** **C — dynamic orchestration via AgentCore Registry.** Existing supervisor patterns (A) continue to work for well-defined workflows, but the primary pattern going forward is Registry-driven discovery.
+
+**Why:** AgentCore Registry already supports this today:
+- Agents register with rich descriptions (MCP server schemas, A2A agent cards, skill definitions)
+- `SearchRegistryRecords` API does semantic search across registered records
+- An orchestrator agent discovers and connects to capabilities at runtime — zero hardcoded integrations
+- Record types: MCP, A2A, AGENT_SKILLS, CUSTOM — covers all catalog agent types
+- Approval workflow ensures only validated agents are discoverable
+
+**What this means for the HCLS toolkit:**
+- Each catalog agent registers in the HCLS Registry on deployment
+- New agents become instantly available to workflows without redeploying the orchestrator
+- Complex HCLS workflows (biomarker discovery, patient genomic analysis, drug research pipelines) compose dynamically from registered agents
+- End-user platforms (Q Desktop, Co-work) could also search the Registry to discover available HCLS capabilities
+
+**The architectural progression:** Static supervisor (today) → Registry-discovered dynamic orchestration (target). Both coexist — static for deterministic pipelines, dynamic for exploratory workflows.
+
+---
+
+## What We Ruled Out
+
+| Option | Why we ruled it out |
+|--------|---------------------|
+| Rebuilding agents AS plugins | Agents serve production users; plugins serve developers. Different concerns. |
+| Creating standalone HCLS MCP servers from scratch | AgentCore Gateway already acts as MCP server. Don't build what exists. |
+| Waiting for migration to complete before starting | Short-term packaging doesn't depend on v2 agents. |
+| Single format for all surfaces | Formats aren't standardized across platforms. Accept thin adapters. |
+| Replacing catalog agents with skills | Skills can't provide scale, compliance, or determinism. Agents are still needed for production. |
+
+---
+
+## Key Architectural Insight
+
+The three catalog agents that already demonstrate the target pattern:
+
+| Agent | What it proves |
+|-------|---------------|
+| **Agent 28** (Biomni) | AgentCore Gateway = MCP server. Any client connects directly. |
+| **Agent 35** (OLS/Terminology) | Custom MCP server deployed to AgentCore Runtime. Managed hosting for MCP tools. |
+| **Agent 36** (C4LS) | Strands `AgentSkills` loads SKILL.md + external MCP connectors. Skills and tools compose at runtime. |
+
+And the AgentCore Registry samples demonstrate the orchestration pattern:
+
+| Sample | What it proves |
+|--------|---------------|
+| **discovery-and-invocation-at-runtime** | Orchestrator discovers MCP + A2A agents via semantic search, connects dynamically, executes — zero hardcoded integrations |
+| **registry-skills-dynamic-discovery** | Agent discovers and loads SKILL.md from Registry at runtime, installs dependencies, executes task |
+| **publish-agentcore-tools-in-registry** | MCP servers and A2A agents register themselves with full connection metadata |
+
+**The full architecture is proven across existing code.** The transformation is assembling these patterns into a coherent HCLS platform, not inventing something new.
+
+---
+
+## The One-Line Pitch
+
+> The HCLS Agents Toolkit becomes a library of healthcare domain capabilities — deployable as production agents, consumable as developer skills, and connectable as MCP tools — serving builders in their IDEs, researchers in Q Desktop, and clinicians through production applications.

--- a/docs/proposals/executive-summary-hcls-toolkit-positioning.md
+++ b/docs/proposals/executive-summary-hcls-toolkit-positioning.md
@@ -1,0 +1,208 @@
+# HCLS Agents Toolkit: Strategic Positioning
+
+> The HCLS Agents Toolkit becomes a library of healthcare domain capabilities — deployable as production agents, consumable as developer skills, and connectable as MCP tools — serving builders in their IDEs, researchers in Q Desktop, and clinicians through production applications.
+
+## Executive Summary
+
+The HCLS Agents Toolkit is a library of healthcare and life sciences domain capabilities — deployable agents, reusable skills, and MCP-based tools — that enables builders and end-users to execute HCLS workflows on AWS. This document describes how the toolkit complements and integrates with the broader ecosystem of AI development tools and consumption surfaces.
+
+---
+
+## Why Now: Customer Signal
+
+Multiple customers are asking for industry-specific AI capabilities delivered through platforms they already use:
+
+- **Large pharma customer** is asking about packaging and presenting Q Desktop as a more unified "research studio" for their scientists
+- **Multiple customers** want to build "Claude for Bioinformaticians" — assistants for biology scientists who can process data at scale without writing code
+- **Across verticals**, customers are looking for an agents platform that supports custom agents, pre-defined agents, skills, MCP servers and tools, and workflows that combine them for multiple personas
+
+The common ask: **domain-specific AI capabilities that non-technical users can access through natural language, without deploying infrastructure themselves.**
+
+The HCLS Agents Toolkit already has the domain capabilities (36+ agents). What's missing is the portable interface layer that makes them accessible to these consumption surfaces.
+
+---
+
+## The Ecosystem
+
+Four distinct offerings serve different audiences at different stages:
+
+| Offering | What it provides | Who it serves |
+|----------|-----------------|---------------|
+| **AWS Agent Toolkit** | Generic AWS best practices — build, deploy, debug, harden agents on AWS | Any developer building agents on AWS |
+| **HCLS Agents Toolkit** (this repo) | Domain-specific capabilities — HCLS workflows, tools, knowledge, and production-ready agents | Builders and end-users in healthcare and life sciences |
+| **AI Coding Assistants** (Claude Code, Kiro, Codex) | Developer IDE experience — code generation, deployment, debugging | Developers building software |
+| **End-User Platforms** (Amazon Q Desktop, Claude Co-work) | Natural language interface for non-technical users to execute workflows | Researchers, clinicians, scientists |
+
+---
+
+## How They Compose
+
+```
+┌─────────────────────────────────────────────────────────────────────────┐
+│                                                                         │
+│   END-USER PLATFORMS (Amazon Q Desktop, Claude Co-work)                 │
+│   Non-technical users execute HCLS workflows in natural language        │
+│                                                                         │
+│   Connects to:                                                          │
+│   • HCLS MCP tools (via AgentCore Gateway/Runtime)                      │
+│   • HCLS Skills (SKILL.md loaded as capabilities)                       │
+│                                                                         │
+├─────────────────────────────────────────────────────────────────────────┤
+│                                                                         │
+│   AI CODING ASSISTANTS (Claude Code, Kiro, Codex)                       │
+│   Developers build, customize, and deploy HCLS agents                   │
+│                                                                         │
+│   Uses:                                                                 │
+│   • AWS Agent Toolkit  → HOW to build agents on AWS                     │
+│   • HCLS Toolkit Plugin → WHAT to build for healthcare/life sciences    │
+│                                                                         │
+├─────────────────────────────────────────────────────────────────────────┤
+│                                                                         │
+│   PRODUCTION RUNTIME (Amazon Bedrock AgentCore)                         │
+│   Deployed agents serve end-users at scale with guardrails              │
+│                                                                         │
+│   • Agent Catalog → assembled, production-hardened agents               │
+│   • AgentCore Gateway → HCLS tools exposed as hosted MCP endpoints      │
+│   • AgentCore Runtime → MCP servers or full agent runtimes              │
+│   • FAST template → full-stack deployment (React + Cognito + CDK)       │
+│   • AgentCore Registry → dynamic discovery for multi-agent workflows    │
+│                                                                         │
+└─────────────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Positioning by Offering
+
+### 1. AWS Agent Toolkit (generic AWS)
+
+**Relationship:** Complementary. The AWS Agent Toolkit teaches coding assistants HOW to build and deploy agents on AWS infrastructure. The HCLS Toolkit teaches them WHAT to build for healthcare and life sciences.
+
+**Integration point:** A developer installs both plugins. The AWS Agent Toolkit handles scaffolding, IAM, deployment, debugging. The HCLS Toolkit provides domain knowledge, tool schemas, workflow patterns, and reference agents.
+
+| AWS Agent Toolkit Skills | HCLS Toolkit Equivalent |
+|--------------------------|-------------------------|
+| `agents-get-started` — scaffold an agent | `hcls-get-started` — scaffold an HCLS agent using catalog patterns |
+| `agents-deploy` — deploy to AgentCore | HCLS agents deploy using the same mechanism |
+| `agents-harden` — guardrails, policies | HCLS adds HIPAA-aware guardrails, PHI handling |
+| `agents-optimize` — evals, cost | HCLS adds domain-specific evaluation (clinical accuracy, scientific rigor) |
+
+### 2. AI Coding Assistants (Claude Code, Kiro, Codex)
+
+**Relationship:** The HCLS Toolkit exposes itself as an installable plugin for coding assistants.
+
+**What developers get:**
+- Skills that guide building HCLS agents (genomics, clinical trials, biomarker discovery, drug research)
+- MCP server configs pointing to domain documentation and APIs
+- Reference to catalog agents as templates and patterns
+- Domain-specific conventions (data formats, ontologies, compliance requirements)
+
+**Multi-assistant support:**
+| Assistant | Format | What they consume |
+|-----------|--------|-------------------|
+| Claude Code | `.claude-plugin/` + SKILL.md | Skills + MCP servers |
+| Kiro | `powers/` + `POWER.md` + `steering/` | Power with steering files + MCP servers |
+| Codex | `.codex-plugin/` + SKILL.md | Skills + MCP servers |
+| Cursor/VS Code/Windsurf | `.mcp.json` | MCP servers directly |
+
+### 3. End-User Platforms (Amazon Q Desktop, Claude Co-work)
+
+**Relationship:** The HCLS Toolkit provides domain tools and skills that non-technical users access directly — without deploying a full agent.
+
+**What end-users get:**
+- Connect to deployed HCLS MCP servers (AgentCore Gateway/Runtime) for domain tools
+- Load HCLS skills as workflow guidance
+- Execute clinical, genomics, and research workflows in natural language
+
+**Example flows:**
+- A researcher connects to the Biomni Gateway (agent 28) → queries 30+ biomedical databases via natural language
+- A clinician connects to the OLS MCP server (agent 35) → standardizes medical terminology against 200+ ontologies
+- A scientist loads the C4LS skills (agent 36) → converts instrument data to standardized formats
+
+**Key distinction:** End-user platforms consume the SAME MCP tools and skills that developers use — but without the IDE context. The deployed AgentCore Gateway/Runtime acts as the bridge.
+
+### 4. HCLS Agents Toolkit (this repo — the unique offering)
+
+**What is unique to this toolkit:**
+- A catalog of 36+ production-ready HCLS agents spanning drug research, clinical trials, genomics, and commercialization
+- Domain-specific MCP tools (ontology lookup, variant interpretation, biomarker databases, clinical trial matching, drug label analysis)
+- HCLS workflow knowledge encoded as portable skills
+- Multi-agent collaboration patterns for complex HCLS workflows (cancer biomarker discovery, clinical trial protocols)
+- HCLS-specific guardrails (HIPAA compliance, PHI handling, clinical validation)
+- Evaluation frameworks for clinical accuracy and scientific rigor
+
+**The catalog remains the core product.** Skills and MCP servers are the portable interface layer that makes catalog capabilities consumable across all surfaces.
+
+---
+
+## Multi-Agent Orchestration via AgentCore Registry
+
+A key differentiator: catalog agents don't just run in isolation — they compose into workflows dynamically.
+
+**AgentCore Registry** provides:
+- A centralized catalog where deployed agents, MCP servers, and skills register themselves with rich descriptions
+- **Semantic search** — an orchestrator finds relevant capabilities using natural language (e.g., "variant interpretation" matches the genomics agent even if those exact words aren't in its name)
+- **Dynamic discovery at runtime** — no hardcoded integrations; the orchestrator builds its toolset per-request
+- **Mixed protocol support** — MCP servers (via Gateway) and A2A agents (via Runtime) discovered from a single search
+- **Approval workflow** — admin-controlled publishing ensures only validated agents are discoverable
+
+**What this enables for HCLS:**
+
+A dynamic orchestrator agent receives "Analyze this patient's genomic data and find matching clinical trials" and at runtime:
+1. Searches the Registry → discovers the variant interpreter agent + the clinical trial matching agent
+2. Connects to both (MCP + A2A)
+3. Executes the multi-step workflow without any hardcoded integration
+
+**New HCLS agents become instantly available to workflows** — register in the Registry, get discovered automatically. No redeployment of the orchestrator.
+
+This transforms the catalog from "pick one agent" to "agents are composable services assembled on demand."
+
+---
+
+## Security and Compliance Position
+
+This toolkit is currently positioned as **demonstrative/non-clinical** — not intended for production use with PHI without appropriate compliance review.
+
+**Current state:**
+- MIT-0 license with explicit disclaimer: not for clinical use, not a substitute for professional medical advice
+- Each customer is responsible for determining HIPAA applicability and entering an AWS BAA
+
+**For the portable interface layer (skills + MCP):**
+- Skills contain workflow knowledge, not patient data — no PHI flows through SKILL.md files
+- MCP tools connect to data sources at runtime — PHI handling depends on the backend, not the skill/MCP layer
+- AgentCore Gateway/Runtime provides authentication (Cognito OAuth2, IAM SigV4) and access control
+- Cedar policies can enforce data access guardrails at the tool level
+
+**Action required:** Formal security review of the MCP tool layer before any customer-facing deployment involving PHI. This is acknowledged as a gap to be addressed in medium-term implementation.
+
+---
+
+## Value Proposition by Persona
+
+| Persona | Current experience | With integrated toolkit |
+|---------|-------------------|------------------------|
+| **HCLS Developer** (building agents) | Clone repo, read READMEs, manually copy templates | Install HCLS + AWS plugins → guided scaffolding, domain knowledge, automated deployment |
+| **Researcher** (exploring data) | Must deploy a full agent to get domain tools | Connect Q Desktop/Co-work to HCLS MCP servers → immediate domain tool access |
+| **Clinician** (executing workflows) | No direct access — needs deployed agent + UI | Connect to AgentCore Gateway → natural language clinical workflows |
+| **Platform team** (building internal tools) | Integrate agents one-by-one | Compose catalog agents + shared MCP tools → modular HCLS platform |
+
+---
+
+## Answering the Market Question
+
+> "Are you building industry-specific modules for Amazon Q Desktop? Can you give us visibility on the roadmap?"
+
+**Answer:** The HCLS Agents Toolkit provides healthcare and life sciences capabilities as portable skills and MCP tools deployable to AgentCore. These are consumable by any MCP-compatible surface — including Amazon Q Desktop, Claude Co-work, coding assistants, and custom applications. The toolkit includes a catalog of 36+ production-ready agents alongside the domain tools and skills that power them. Builders can deploy complete agents for production use, or connect end-user platforms directly to HCLS domain tools for exploratory and operational workflows.
+
+---
+
+## Summary
+
+The HCLS Agents Toolkit is positioned as the **domain layer** in a composable stack:
+
+- **AWS Agent Toolkit** = infrastructure best practices (how to build on AWS)
+- **HCLS Agents Toolkit** = domain capabilities (what to build for healthcare/life sciences)
+- **Coding Assistants** = developer experience (who builds it)
+- **End-User Platforms** = consumption experience (who uses it)
+
+Each layer is independently valuable. Together, they enable a complete path from exploration to production for HCLS AI workflows on AWS.

--- a/docs/proposals/executive-summary-hcls-toolkit-positioning.md
+++ b/docs/proposals/executive-summary-hcls-toolkit-positioning.md
@@ -8,14 +8,7 @@ The HCLS Agents Toolkit is a library of healthcare and life sciences domain capa
 
 ---
 
-## Why Now: Customer Signal
-
-Multiple customers are asking for industry-specific AI capabilities delivered through platforms they already use:
-
-- **Large pharma customer** is asking about packaging and presenting Q Desktop as a more unified "research studio" for their scientists
-- **Multiple customers** want to build "Claude for Bioinformaticians" — assistants for biology scientists who can process data at scale without writing code
-- **Across verticals**, customers are looking for an agents platform that supports custom agents, pre-defined agents, skills, MCP servers and tools, and workflows that combine them for multiple personas
-
+## Why Now: 
 The common ask: **domain-specific AI capabilities that non-technical users can access through natural language, without deploying infrastructure themselves.**
 
 The HCLS Agents Toolkit already has the domain capabilities (36+ agents). What's missing is the portable interface layer that makes them accessible to these consumption surfaces.

--- a/docs/proposals/repository-transformation-roadmap.md
+++ b/docs/proposals/repository-transformation-roadmap.md
@@ -1,0 +1,652 @@
+# HCLS Agents Toolkit: Repository Transformation Roadmap
+
+## Context
+
+This document proposes changes to transform the HCLS Agents Toolkit repository from a collection of standalone agents into a composable platform where domain capabilities are expressed as portable skills, MCP tools, and production-ready agents. These changes complement the ongoing parallel effort to migrate legacy Bedrock agents (v1 CloudFormation/Lambda pattern) to AgentCore with the Strands framework.
+
+---
+
+## Current State
+
+### What exists today
+
+| Component | State | Pattern |
+|-----------|-------|---------|
+| 36+ catalog agents | Mixed — some v1 (CloudFormation/Lambda), some v2 (AgentCore/Strands) | Self-contained, independently deployable |
+| `agentcore_template/` | Production-ready | Backend-only AgentCore stack (Runtime, Gateway, Identity, Memory, Observability) + Streamlit UI |
+| [FAST template](https://github.com/awslabs/fullstack-solution-template-for-agentcore) | External, production-ready | Full-stack: React frontend (Amplify) + Cognito auth + AgentCore backend + CDK/Terraform deployment |
+| Agent 28 (Research/Biomni) | Production-ready | AgentCore Gateway as MCP endpoint with 30+ database tools |
+| Agent 35 (Terminology/OLS) | Production-ready | Built on FAST template + custom OLS MCP server on AgentCore Runtime |
+| Agent 36 (C4LS) | Production-ready | Strands `AgentSkills` (SKILL.md) + external MCP connectors |
+| Kiro Power | Functional | `powers/hcls-agentcore-builder/` with steering files + MCP configs |
+| Multi-agent collaboration | Functional | Cancer biomarker discovery, clinical trials, competitive intel |
+
+### Two deployment templates available
+
+| Template | Scope | Use when |
+|----------|-------|----------|
+| **`agentcore_template/`** (this repo) | Backend-only: AgentCore Runtime + Gateway + Memory + Streamlit dev UI | Rapid prototyping, backend development, or BYO frontend |
+| **[FAST](https://github.com/awslabs/fullstack-solution-template-for-agentcore)** (external) | Full-stack: React/Amplify frontend + Cognito + AgentCore backend + CDK | Production deployments needing a complete, secured web application |
+
+Agent 35 (Terminology) demonstrates the FAST pattern: fork FAST, add domain-specific tools (OLS MCP server), customize the agent and frontend — production-ready full-stack deployment with minimal effort. This is the recommended approach for production catalog agents going forward.
+
+### Ongoing parallel work
+
+The v1-to-v2 migration project is converting legacy CloudFormation/Lambda agents to AgentCore/Strands. This roadmap does NOT block on that migration — it builds the plugin/skills/MCP infrastructure that migrated agents will naturally fit into once converted.
+
+---
+
+## Architectural Principles
+
+1. **MCP servers are the universal tool primitive** — deploy once to AgentCore, consumable by any MCP client (IDE, Co-work, Q Desktop, other agents)
+2. **Skills are portable knowledge** — SKILL.md content is the source of truth, packaged per-surface with thin adapters
+3. **Catalog agents are assembled products** — compose skills + MCP tools + guardrails + system prompt into production runtimes
+4. **No duplication** — tools live in one place (MCP server); skills live in one place (SKILL.md); agents reference both
+5. **Registry-driven composition** — deployed agents register in AgentCore Registry and become dynamically discoverable for multi-agent workflows
+
+---
+
+## Short Term (4-6 weeks): Package What Exists
+
+**Goal:** Make the repo installable as a plugin and demonstrate the integration story. No new MCP servers or major refactoring.
+
+### Deliverables
+
+#### 1. Plugin marketplace manifest
+
+Create `.claude-plugin/marketplace.json` registering this repo as an installable plugin source.
+
+```
+.claude-plugin/
+  marketplace.json
+```
+
+#### 2. HCLS plugin skeleton
+
+```
+plugins/
+  hcls-agents/
+    .claude-plugin/plugin.json    ← Claude Code
+    .codex-plugin/plugin.json     ← Codex
+    .mcp.json                     ← MCP clients (Cursor, VS Code, etc.)
+    README.md
+    skills/
+      hcls-get-started/SKILL.md
+      hcls-build-agent/SKILL.md
+      hcls-deploy-agent/SKILL.md
+```
+
+#### 3. Initial skills (3-4, extracted from existing content)
+
+| Skill | Source material | What it teaches |
+|-------|-----------------|-----------------|
+| `hcls-get-started` | Kiro Power `POWER.md` + steering files | How to start building an HCLS agent using this repo |
+| `hcls-build-agent` | `agentcore_template/` README + agent patterns | How to structure tools, prompts, and workflows for HCLS |
+| `hcls-deploy-agent` | Deployment scripts, OLS deployment guide | How to deploy MCP servers and agents to AgentCore |
+| `hcls-domain-conventions` | Extracted from agent READMEs | HCLS data formats, ontologies, compliance, PHI handling |
+
+#### 4. MCP configuration pointing to existing servers
+
+The `.mcp.json` references already-deployed or available MCP servers:
+
+```json
+{
+  "mcpServers": {
+    "awsknowledge": {
+      "type": "http",
+      "url": "https://knowledge-mcp.global.api.aws"
+    },
+    "agentcore-docs": {
+      "command": "uvx",
+      "args": ["awslabs.amazon-bedrock-agentcore-mcp-server@latest"]
+    },
+    "strands-docs": {
+      "command": "uvx",
+      "args": ["strands-agents-mcp-server"]
+    },
+    "healthomics": {
+      "command": "uvx",
+      "args": ["awslabs.aws-healthomics-mcp-server@latest"]
+    }
+  }
+}
+```
+
+#### 5. Integration guide
+
+A README documenting:
+- How to install the HCLS plugin in Claude Code (`/plugin marketplace add ...`)
+- How to configure MCP servers in Co-work and Q Desktop
+- How the HCLS plugin complements the AWS Agent Toolkit
+- Which catalog agents are directly accessible as MCP endpoints
+
+#### 6. Maintain Kiro Power in parallel
+
+Keep `powers/hcls-agentcore-builder/` as-is — update its content to stay in sync with the new skills.
+
+### Effort estimate
+
+| Task | Estimate |
+|------|----------|
+| Plugin manifests + structure | 1 day |
+| Extract 3-4 skills from existing content | 1 week |
+| MCP config + integration guide | 2-3 days |
+| Testing across Claude Code + Kiro | 2-3 days |
+| **Total** | **~2 weeks** |
+
+### Dependencies on parallel migration
+
+None. This phase uses existing content and deployed infrastructure.
+
+---
+
+## Medium Term (2-3 months): Domain Skills + MCP Tools
+
+**Goal:** Build HCLS-specific skills with real workflow guidance and demonstrate end-user platform consumption (Q Desktop, Co-work connecting to deployed HCLS tools).
+
+### Deliverables
+
+#### 1. Domain-specific skills (5-8)
+
+Skills that encode HCLS workflow knowledge, referencing catalog agents and MCP tools:
+
+| Skill | Domain | What it enables |
+|-------|--------|-----------------|
+| `hcls-genomics-interpretation` | Genomics | Guide variant interpretation workflow (VCF → annotated → clinical report) |
+| `hcls-clinical-trial-matching` | Clinical | Match patients to trials, generate protocols |
+| `hcls-biomarker-discovery` | Research | Multi-agent biomarker discovery workflow |
+| `hcls-drug-research` | Pharma | Protein design, DMTA cycles, drug label analysis |
+| `hcls-medical-terminology` | Standards | Ontology standardization, CDISC mapping |
+| `hcls-regulatory-compliance` | Compliance | HIPAA, PHI handling, clinical data guardrails |
+| `hcls-lab-data-standardization` | Lab ops | Instrument data to Allotrope (extends C4LS pattern) |
+| `hcls-safety-signal-detection` | Pharmacovigilance | Adverse event analysis, signal detection |
+
+Each skill includes:
+- Workflow steps
+- Which MCP tools to use
+- References to catalog agents as implementations
+- Domain-specific guardrails and validation
+
+#### 2. HCLS MCP server consolidation
+
+Identify and document which catalog agents already expose MCP-accessible tools:
+
+| Catalog Agent | MCP Endpoint | Tools available |
+|---------------|-------------|-----------------|
+| Agent 28 (Research/Biomni) | AgentCore Gateway | 30+ database query tools |
+| Agent 35 (Terminology/OLS) | AgentCore Runtime | 7 ontology tools |
+| Agent 36 (C4LS) | External (PubMed, OpenTargets) | Literature search, target lookup |
+
+For agents completing v2 migration during this phase, ensure their Gateway tools are documented and connectable by end-user platforms.
+
+#### 3. End-user platform demonstrations
+
+Create documentation and demo configs showing:
+- **Q Desktop:** Connect to deployed HCLS Gateway → execute research queries
+- **Claude Co-work:** Load HCLS skills + connect MCP → run clinical workflows
+- **Video/walkthrough:** Non-technical user performing HCLS workflow through natural language
+
+#### 4. Skill format adapters
+
+Create tooling or templates to generate surface-specific skill packaging from a single source:
+
+```
+skills/
+  hcls-genomics-interpretation/
+    SKILL.md                    ← source of truth
+    references/                 ← domain docs
+    scripts/                    ← executable helpers (optional)
+
+build-skills.sh                 ← generates:
+  → plugins/hcls-agents/skills/ (Claude Code format)
+  → powers/ steering files      (Kiro format)
+```
+
+#### 5. Co-work / Q Desktop SKILL.md format
+
+Ensure skills are compatible with both Co-work and Q Desktop's SKILL.md format (YAML frontmatter + markdown body with triggers/descriptions).
+
+### Effort estimate
+
+| Task | Estimate |
+|------|----------|
+| Write 5-8 domain skills | 3-4 weeks |
+| MCP endpoint documentation + configs | 1 week |
+| End-user platform demos | 2 weeks |
+| Skill format adapter tooling | 1 week |
+| Testing + iteration | 2 weeks |
+| **Total** | **~2-3 months** |
+
+### Dependencies on parallel migration
+
+- Skills can reference v2 agents as they complete migration
+- New MCP Gateway endpoints become available as agents are migrated
+- Skills should be written to reference the target (v2) architecture, with notes on which agents are still in migration
+
+---
+
+## Long Term (6+ months): Composable HCLS Platform
+
+**Goal:** Fully decomposed architecture where every catalog agent's capabilities are independently consumable as skills + MCP tools, registered in AgentCore Registry for dynamic discovery, and composable into multi-agent workflows by an orchestrator.
+
+### Deliverables
+
+#### 1. Every catalog agent decomposed and registered
+
+As the v2 migration completes, each agent:
+- **Deploys tools → AgentCore Gateway or Runtime** (MCP-accessible)
+- **Publishes knowledge → SKILL.md** (portable across surfaces)
+- **Registers in AgentCore Registry** (discoverable for orchestration)
+- **Runs as assembled agent → AgentCore Runtime** (production deployment)
+
+Example for the variant interpreter agent:
+
+```
+agents_catalog/17-variant-interpreter-agent/
+├── skills/
+│   └── variant-interpretation/SKILL.md     ← workflow knowledge
+├── mcp-server/
+│   └── (deployed to AgentCore Runtime)     ← genomics tools
+├── agent/
+│   └── main.py                             ← assembled agent (skills + tools + prompt)
+├── registry/
+│   └── record.json                         ← AgentCore Registry record (MCP + A2A descriptors)
+└── README.md
+```
+
+On deployment, the agent automatically registers in the HCLS AgentCore Registry with:
+- MCP server descriptor (tool schemas, transport config)
+- A2A agent card (capabilities, skills, URL)
+- Rich description for semantic search discoverability
+
+#### 2. Dynamic multi-agent orchestration via AgentCore Registry
+
+**This is the key architectural differentiator.** An HCLS orchestrator agent uses the AgentCore Registry to dynamically compose workflows:
+
+```
+User: "Analyze this patient's genomic data and find matching clinical trials"
+
+Orchestrator Agent:
+  1. SearchRegistryRecords("variant interpretation genomics")
+     → discovers: variant-interpreter-agent (A2A) + genomics-store (MCP)
+  2. SearchRegistryRecords("clinical trial matching eligibility")
+     → discovers: clinical-trial-matching-agent (A2A)
+  3. Connects to discovered agents dynamically
+  4. Executes: interpret variants → extract findings → match to trials
+  5. Returns: integrated report
+```
+
+**How it works (proven pattern from AgentCore samples):**
+- Registry stores records with types: `MCP`, `A2A`, `AGENT_SKILLS`, `CUSTOM`
+- `SearchRegistryRecords` API does semantic search over approved records
+- Orchestrator parses descriptors to get connection metadata (MCP server schemas, A2A agent cards)
+- Creates live connections: `MCPClient` for Gateway tools, `@tool` wrappers for A2A agents
+- Executes using a Strands Agent built with only the dynamically discovered tools
+
+**New agents become instantly available to workflows** — deploy, register, done. No orchestrator redeployment.
+
+**HCLS-specific orchestration patterns:**
+
+| Workflow | Agents composed | Trigger |
+|----------|----------------|---------|
+| Patient genomic analysis | Variant interpreter + Clinical trial matcher + Literature search | "Analyze VCF and recommend trials" |
+| Biomarker discovery | Database analyst + Pathway analyst + Clinical evidence + Statistician | "Find CDx markers for NSCLC" |
+| Drug research pipeline | Protein design + DMTA orchestrator + Safety signal detection | "Evaluate compound X" |
+| Clinical documentation | Prior auth + PreVisit questionnaire + Medical terminology | "Prepare patient visit" |
+
+#### 3. HCLS AgentCore Registry
+
+A curated registry of all HCLS agents, MCP tools, and skills:
+
+| Record | Type | Domain | What it exposes |
+|--------|------|--------|-----------------|
+| Biomni Research Gateway | MCP | Multi-database research | 30+ database query tools |
+| OLS Terminology Server | MCP | Medical ontologies | 7 ontology tools |
+| Genomics Variant Store | MCP | Genomics | HealthOmics queries, annotation |
+| Variant Interpreter | A2A | Genomics | Clinical variant interpretation |
+| Clinical Trial Matcher | A2A | Clinical | Trial eligibility, matching |
+| Biomarker Discovery Suite | A2A | Research | Multi-agent biomarker workflow |
+| Drug Label Analyzer | A2A | Regulatory | Label analysis, comparison |
+| PubMed Connector | MCP | Literature | Search, fetch citations |
+| OpenTargets | MCP | Target validation | Gene/disease lookup |
+| Instrument-to-Allotrope | AGENT_SKILLS | Lab ops | Data standardization skill |
+
+End-user platforms, coding assistants, and orchestrator agents all discover from the same registry.
+
+#### 4. Multi-agent skill composition
+
+Skills that orchestrate multiple MCP tools and reference multi-agent patterns:
+
+```
+hcls-cancer-biomarker-discovery/SKILL.md
+  → Uses: biomni-gateway tools (databases)
+  → Uses: genomics-store tools (variants)
+  → Uses: pubmed tools (literature)
+  → References: multi_agent_collaboration/cancer_biomarker_discovery/
+  → Workflow: discovery → validation → clinical evidence
+```
+
+#### 5. Enterprise distribution readiness
+
+Prepare for future admin-push capabilities (currently not available in Co-work or Q Desktop):
+- Modular packaging: each HCLS domain is independently installable
+- Configuration templates for org-wide MCP server connection
+- Guardrail configs exportable as Cedar policies
+- Documentation for platform teams integrating HCLS tools into custom applications
+
+#### 6. Community contribution framework
+
+Everyone building HCLS agents is solving similar domain problems — the community should benefit from shared skills, tools, and agents. Contributions are welcome immediately and don't need to wait for full platform maturity.
+
+**What contributors can add:**
+
+| Contribution type | What to submit | Template provided | Review process |
+|-------------------|---------------|-------------------|----------------|
+| **Skills** | SKILL.md + references/ + scripts/ (executable code the AI assistant runs) | `templates/skill/` | Domain expert review for accuracy |
+| **Scripts** | Standalone Python tools (parsers, validators, converters) usable by skills or independently | `templates/script/` | Code review + test coverage |
+| **MCP Servers** | MCP server deployable to AgentCore | `templates/mcp-server/` | Security review + deployment test |
+| **Plugins** | Bundled skill + MCP config + manifest | `templates/plugin/` | Integration test across surfaces |
+| **Agents** | Full AgentCore agent (existing pattern) | `agentcore_template/` | Architecture review + deployment test |
+
+**Note on skills:** Skills are NOT just documentation. Following the [Anthropic Skills standard](https://github.com/anthropics/skills), a skill includes:
+- `SKILL.md` — instructions that guide the AI assistant through a workflow
+- `references/` — domain knowledge, schemas, runbooks the assistant reads for context
+- `scripts/` — **executable code** (Python, bash) that the assistant runs to accomplish tasks (parsers, validators, converters, API clients, data transformers)
+
+Example from the C4LS agent already in this repo (`agents_catalog/36-C4LS-example-agent/`):
+```
+skills/instrument-data-to-allotrope/
+├── SKILL.md                          ← workflow instructions
+├── scripts/
+│   ├── convert_to_asm.py            ← executable: converts instrument data
+│   ├── flatten_asm.py               ← executable: ASM → CSV
+│   ├── export_parser.py             ← executable: generates standalone parser code
+│   └── validate_asm.py              ← executable: validates output quality
+└── references/
+    ├── supported_instruments.md     ← domain knowledge
+    ├── asm_schema_overview.md       ← schema reference
+    └── field_classification_guide.md
+```
+
+See also: [Anthropic's mcp-builder skill](https://github.com/anthropics/skills/tree/main/skills/mcp-builder) as a reference for the scripts/ pattern.
+
+**Contribution structure:**
+
+```
+contributions/
+├── skills/                         ← Community-contributed skills
+│   ├── <contributor>-<skill-name>/
+│   │   ├── SKILL.md
+│   │   ├── references/
+│   │   └── scripts/
+├── mcp-servers/                    ← Community MCP server implementations
+│   ├── <contributor>-<server-name>/
+│   │   ├── server.py
+│   │   ├── requirements.txt
+│   │   └── README.md
+├── scripts/                        ← Standalone utility scripts
+│   ├── <contributor>-<script-name>/
+│   │   ├── <script>.py
+│   │   └── README.md
+└── templates/                      ← Templates for each contribution type
+    ├── skill/
+    ├── script/
+    ├── mcp-server/
+    └── plugin/
+```
+
+**Contribution workflow:**
+
+1. Contributor forks the repo
+2. Creates their contribution using the appropriate template
+3. Submits PR with:
+   - Description of the HCLS use case it addresses
+   - Which personas benefit (researcher, clinician, developer, etc.)
+   - Test instructions or demo script
+4. Review: domain expert validates accuracy, maintainer reviews code/security
+5. Merge → automatically available in the plugin + optionally registered in the HCLS Registry
+
+**Graduated promotion path:**
+
+```
+Community contribution (contributions/)
+  → Validated and promoted to agents_catalog/ (if full agent)
+  → Included in HCLS plugin skills/ (if skill)
+  → Registered in HCLS AgentCore Registry (if deployable)
+```
+
+**What makes a good contribution:**
+- Solves a real HCLS workflow problem (not generic)
+- Includes a README explaining the use case and how to test
+- For skills: validated by someone with domain expertise
+- For MCP servers: deployable to AgentCore with provided scripts
+- For agents: follows the `agentcore_template/` pattern
+
+**Immediate call to action (post-exec approval):**
+
+> The HCLS Agents Toolkit is now open for community contributions. If you're building skills, scripts, MCP tools, or agents for healthcare and life sciences workflows — contribute them here. Your work becomes instantly available to developers in their IDEs, researchers in Q Desktop, and production applications via AgentCore. Start with a skill (just a SKILL.md file) or a standalone script — no infrastructure required.
+
+> We're specifically looking for contributions in: genomics/variant analysis, clinical trial workflows, drug discovery pipelines, regulatory/compliance automation, lab data standardization, medical terminology, and real-world evidence generation.
+
+### Effort estimate
+
+| Task | Estimate |
+|------|----------|
+| Decompose remaining catalog agents (as migration completes) | Ongoing, per-agent |
+| Create HCLS AgentCore Registry + register existing v2 agents | 2-3 weeks |
+| Build HCLS orchestrator agent (dynamic discovery pattern) | 3-4 weeks |
+| Multi-agent skill composition | 4-6 weeks |
+| Enterprise distribution templates | 2-3 weeks |
+| Contribution framework | 2-3 weeks |
+| **Total** | **6+ months (overlaps with migration)** |
+
+### Dependencies on parallel migration
+
+- **Critical dependency:** Long-term decomposition requires agents to be on v2 (AgentCore/Strands) to expose Gateway/Runtime MCP endpoints and register in the Registry
+- The migration project delivers the agents; this roadmap delivers the plugin/skills/MCP/Registry layer on top
+- Coordinate: as each agent completes migration, immediately create its skill + register in the HCLS Registry
+- The orchestrator becomes more powerful with each agent registered — value compounds over time
+
+---
+
+## Coordination with v1 → v2 Migration
+
+The v2 migration is an opportunity to build the portable interface layer simultaneously — rather than migrating first and adding skills/registry later as a second pass. The following recommendations help migration owners deliver both at once with minimal extra effort.
+
+### Recommendations for Migration Project Owners
+
+**When migrating each agent, additionally deliver these artifacts (medium-term requirements):**
+
+#### 1. Extract a SKILL.md during migration
+
+While converting the agent's logic to Strands, the migration owner already deeply understands the agent's workflow, domain knowledge, and tool interactions. Capture this as a SKILL.md at that moment — it costs 1-2 hours of extra work vs. having someone else reverse-engineer it later.
+
+**Template for migration owners:**
+
+```
+skills/<workflow-name>/
+├── SKILL.md              ← workflow instructions (template below)
+├── scripts/              ← executable code the AI assistant can run
+│   ├── validate.py       ← e.g., validate output format
+│   ├── transform.py      ← e.g., data transformation
+│   └── query.py          ← e.g., API query helper
+└── references/           ← domain knowledge for context
+    ├── data_formats.md   ← relevant schemas, ontologies
+    └── examples.md       ← sample inputs/outputs
+```
+
+**SKILL.md template:**
+
+```markdown
+---
+name: <agent-domain>-<workflow>
+description: <one-line description of what this skill teaches an AI assistant to do>
+---
+
+# <Workflow Name>
+
+## When to use this skill
+<What user request triggers this workflow>
+
+## Workflow steps
+1. <Step — which tool or script to call and why>
+2. ...
+
+## Scripts
+- `scripts/validate.py` — run to validate <what>
+- `scripts/transform.py` — run to convert <input> to <output>
+
+## Tools required (via MCP)
+- <tool_name> — available via <MCP server / Gateway name>
+
+## Domain knowledge
+<Key domain context the AI assistant needs — data formats, ontologies, validation rules>
+See references/ for detailed schemas and examples.
+
+## References
+- Agent implementation: agents_catalog/<agent-folder>/
+- MCP endpoint: <Gateway/Runtime URL or SSM parameter>
+```
+
+#### 2. Expose tools via AgentCore Gateway (not just local Strands tools)
+
+When moving Lambda action groups to Strands tools, also configure them as Gateway targets. This makes the tools accessible beyond the agent itself — to end-user platforms, coding assistants, and other agents.
+
+**Concrete action:** For each tool function in the migrated agent, add a corresponding Gateway Lambda target in the `prerequisite/` infrastructure. Follow the pattern from agent 28 (Biomni Gateway).
+
+#### 3. Create a Registry record JSON
+
+Include a `registry/record.json` in the agent folder that can be used to register the agent post-deployment:
+
+```json
+{
+  "name": "<agent-name>",
+  "description": "<rich description for semantic search>",
+  "descriptorType": "MCP",
+  "descriptors": {
+    "mcp": {
+      "server": { "inlineContent": "<MCP server schema JSON>" },
+      "tools": { "inlineContent": "<tool schemas JSON>" }
+    }
+  }
+}
+```
+
+For agents that should also be invocable as A2A agents, include an `a2a` descriptor with the agent card.
+
+#### 4. Follow the target folder structure
+
+Migrated agents should land in this structure:
+
+```
+agents_catalog/<NN>-<agent-name>/
+├── agent/                          ← Strands agent code (main.py, tools/, config/)
+├── prerequisite/                   ← Infrastructure (Gateway, Lambda, Cognito)
+├── skills/
+│   └── <workflow>/
+│       ├── SKILL.md                ← NEW: workflow instructions
+│       ├── scripts/                ← NEW: executable code (parsers, validators, etc.)
+│       └── references/             ← NEW: domain knowledge docs
+├── registry/
+│   └── record.json                 ← NEW: AgentCore Registry record
+├── tests/                          ← Test scripts
+└── README.md                       ← Updated with MCP endpoint info
+```
+
+**Two template options (both acceptable):**
+- `agentcore_template/` → backend AgentCore stack + Streamlit UI. Good for agents where the focus is on tools/logic, or where a custom frontend exists.
+- [FAST](https://github.com/awslabs/fullstack-solution-template-for-agentcore) → full-stack (React/Amplify + Cognito + CDK). Good when a complete, secured web application is needed. Agent 35 (Terminology) demonstrates this pattern.
+
+Neither is required — contributors choose based on their deployment needs.
+
+#### 5. Document the MCP endpoint in README
+
+After migration, the README should include a "Connect to this agent's tools" section:
+
+```markdown
+## Connect via MCP
+
+This agent's tools are accessible as an MCP endpoint via AgentCore Gateway.
+
+**For Claude Code / Kiro / Cursor:**
+Add to your `.mcp.json`:
+\```json
+{
+  "hcls-<agent>": {
+    "type": "http",
+    "url": "<Gateway MCP URL from SSM parameter>"
+  }
+}
+\```
+
+**For Amazon Q Desktop / Claude Co-work:**
+Settings → Capabilities → Add MCP → paste the URL above
+```
+
+### Migration checklist (per agent)
+
+| Step | Standard migration | Additional for this roadmap | Extra effort |
+|------|-------------------|---------------------------|--------------|
+| Convert Lambda to Strands tools | ✅ | Also add as Gateway targets | +2-4 hours |
+| Deploy to AgentCore Runtime | ✅ | Create registry/record.json | +1 hour |
+| Write/update README | ✅ | Add MCP connection instructions | +30 min |
+| Test agent works | ✅ | Test MCP endpoint independently | +1 hour |
+| — | — | Extract SKILL.md | +1-2 hours |
+| **Total extra per agent** | | | **~1 day** |
+
+### Phased coordination
+
+| Migration phase | This roadmap's action | Who |
+|----------------|----------------------|-----|
+| Agent migrated to Strands | Extract SKILL.md from agent's workflow knowledge | Migration owner |
+| Agent tools moved to AgentCore Gateway | Document MCP endpoint, add to plugin `.mcp.json` | Migration owner + this project |
+| Agent deployed to AgentCore Runtime | Register in HCLS AgentCore Registry | Automated via CI or migration owner |
+| Agent validated in production | Reference from skills as "production-ready implementation" | This project |
+| Agent registered in Registry | Automatically discoverable by orchestrator | Automatic |
+
+**The two projects are complementary:** Migration provides the v2 agents with ~1 day of extra effort per agent to produce the skill, Registry record, and MCP documentation. This roadmap provides the infrastructure (plugin packaging, Registry setup, orchestrator) that consumes those artifacts. Neither blocks the other in the short term. Each migrated agent immediately gains discoverability and composability.
+
+---
+
+## Success Metrics
+
+| Phase | Metric | Target |
+|-------|--------|--------|
+| Short term | Plugin installable and functional in Claude Code + Kiro | Both tested, documented |
+| Short term | Builder scaffolds + deploys an HCLS agent using skills (timed) | Under 30 min from clone to deployed agent |
+| Short term | Internal builders actively using the plugin | 10+ within 6 weeks |
+| Medium term | Non-technical user executes HCLS workflow via Q Desktop/Co-work | 3+ recorded demos with distinct personas |
+| Medium term | Domain skills cover major HCLS verticals | 5-8 skills, each validated by domain expert |
+| Medium term | Design partner feedback collected | 2-3 customers test and provide feedback |
+| Long term | Catalog agents registered in HCLS AgentCore Registry | 100% of v2 agents |
+| Long term | Orchestrator successfully composes multi-agent workflows | 4+ cross-agent workflows demonstrated |
+| Long term | External contributions via skill/MCP/Registry framework | 5+ community contributions |
+| Long term | Customer deployment using the toolkit | 1+ customer running HCLS tools in production |
+
+---
+
+## Risks and Mitigations
+
+| Risk | Impact | Mitigation |
+|------|--------|------------|
+| Plugin formats diverge across surfaces | Skills need per-surface maintenance | Invest in shared source + adapter tooling (medium term) |
+| No enterprise admin-push mechanism yet | Can't silently deploy to org users | Document manual setup; prepare for when platforms add this |
+| v2 migration delays | Fewer agents have MCP endpoints | Short/medium term doesn't depend on migration; long term adjusts timeline |
+| Skill quality/accuracy in clinical domain | Incorrect guidance in healthcare context | Domain expert review for all HCLS skills; disclaimers for non-clinical use |
+| MCP server maintenance burden | Each deployed server needs upkeep | Consolidate related tools into fewer, larger Gateway deployments |
+
+---
+
+## Summary
+
+| Phase | Theme | Key outcome |
+|-------|-------|-------------|
+| **Short term** (4-6 weeks) | Package what exists | Repo is an installable plugin; builders get guided skills |
+| **Medium term** (2-3 months) | Domain skills + platform demos | Non-technical users access HCLS tools; 5-8 domain skills; design partner feedback |
+| **Long term** (6+ months) | Composable platform + orchestration | Agents registered in Registry; dynamic multi-agent workflows; community contributions |
+
+The transformation preserves the catalog as the core product while adding:
+- A **portable interface layer** (skills + MCP) for accessibility across consumption surfaces
+- A **registry and orchestration layer** (AgentCore Registry + dynamic discovery) for composable multi-agent workflows
+
+Together, these enable the "research studio" and "Claude for Bioinformaticians" experiences customers are asking for — domain capabilities accessible to any persona, composable into any workflow, deployable to production with guardrails.

--- a/docs/proposals/repository-transformation-roadmap.md
+++ b/docs/proposals/repository-transformation-roadmap.md
@@ -112,15 +112,52 @@ The `.mcp.json` references already-deployed or available MCP servers:
 }
 ```
 
-#### 5. Integration guide
+#### 5. Integration with AWS Agent Toolkit
+
+The [AWS Agent Toolkit](https://github.com/aws/agent-toolkit-for-aws) provides three plugins that complement the HCLS toolkit. Builders install both — AWS plugins for infrastructure best practices, HCLS plugin for domain knowledge.
+
+**AWS Agent Toolkit plugins and how they integrate with HCLS workflows:**
+
+| AWS Plugin | Capabilities | How HCLS builders use it |
+|------------|-------------|--------------------------|
+| **aws-agents** | 7 skills covering agent lifecycle: scaffolding, building, connecting tools, deploying, debugging, hardening, optimizing | Scaffold new HCLS agents, deploy to AgentCore, debug tool selection, add Cedar policies for PHI, run evaluations |
+| **aws-core** | 12 skills + MCP server for 300+ AWS services: CDK/CloudFormation, Lambda, S3, IAM, serverless, cost optimization | Manage agent infrastructure — deploy CloudFormation stacks, create Lambda action groups, configure IAM roles |
+| **aws-data-analytics** | 7 skills for data lake, ETL, vector storage: S3 Tables, Glue, Athena, Redshift connectors | For data-heavy agents — query biomarker databases, create Iceberg tables for genomics data, connect to external DBs |
+
+**The integration model:**
+
+```
+Builder's AI coding assistant
+├── AWS Agent Toolkit (installed)
+│   ├── aws-agents     → knows HOW to build/deploy/debug agents on AWS
+│   ├── aws-core       → knows HOW to manage AWS infrastructure
+│   └── aws-data-analytics → knows HOW to work with data services
+│
+├── HCLS Agents Toolkit (installed)
+│   ├── hcls-agents    → knows WHAT to build for healthcare/life sciences
+│   │   ├── Domain skills (genomics, clinical, biomarker, drug research)
+│   │   ├── HCLS MCP servers (HealthOmics, AgentCore docs, Strands docs)
+│   │   └── References to catalog agents as patterns
+│   └── (future: additional HCLS domain plugins)
+│
+└── Combined effect: assistant can scaffold an HCLS agent, add domain tools,
+    deploy to AgentCore, apply HIPAA guardrails, and run clinical evaluations
+    — all guided by both toolkits working together
+```
+
+**Example combined workflow:** A builder says "Create a variant interpretation agent with ClinVar access and deploy it." The `aws-agents` skills handle scaffolding and deployment. The HCLS skills provide the domain knowledge (how to structure genomics tools, which ontologies to use, what the clinical interpretation workflow looks like). The MCP servers from both toolkits give the assistant access to AWS docs and HCLS-specific documentation.
+
+The HCLS plugin does NOT duplicate what the AWS Agent Toolkit already provides — it layers domain-specific knowledge on top of the generic AWS agent development workflow.
+
+#### 6. Integration guide
 
 A README documenting:
-- How to install the HCLS plugin in Claude Code (`/plugin marketplace add ...`)
+- How to install both the AWS Agent Toolkit and HCLS plugin together
 - How to configure MCP servers in Co-work and Q Desktop
-- How the HCLS plugin complements the AWS Agent Toolkit
 - Which catalog agents are directly accessible as MCP endpoints
+- Workflow examples showing both plugins working together (e.g., "use aws-agents to deploy, hcls-agents to customize for genomics")
 
-#### 6. Maintain Kiro Power in parallel
+#### 7. Maintain Kiro Power in parallel
 
 Keep `powers/hcls-agentcore-builder/` as-is — update its content to stay in sync with the new skills.
 
@@ -130,9 +167,10 @@ Keep `powers/hcls-agentcore-builder/` as-is — update its content to stay in sy
 |------|----------|
 | Plugin manifests + structure | 1 day |
 | Extract 3-4 skills from existing content | 1 week |
-| MCP config + integration guide | 2-3 days |
+| AWS Agent Toolkit integration (config, guide, workflow examples) | 2-3 days |
+| HCLS MCP config + end-user platform guide | 2-3 days |
 | Testing across Claude Code + Kiro | 2-3 days |
-| **Total** | **~2 weeks** |
+| **Total** | **~2.5 weeks** |
 
 ### Dependencies on parallel migration
 


### PR DESCRIPTION
## Summary

Strategic proposal for evolving the HCLS Agents Toolkit into a composable platform that integrates with the AWS Agent Toolkit ecosystem.

- **Executive summary** — positioning across coding assistants (Claude Code, Kiro, Codex), end-user platforms (Q Desktop, Co-work), AWS Agent Toolkit, and this repo unique HCLS offering
- **Transformation roadmap** — phased plan (short/medium/long term) with coordination guidance for the v1-to-v2 migration, community contribution framework, and AgentCore Registry-driven multi-agent orchestration
- **Decision log** — architectural choices, rationale, and proof points from existing agents (28, 35, 36)

## Context

Customers are asking for industry-specific AI modules accessible to non-technical users. This proposal outlines how to make the existing catalog of 36+ HCLS agents accessible as portable skills, MCP tools, and registry-discoverable services — serving builders in IDEs, researchers in Q Desktop, and clinicians through production applications.

## Files

- docs/proposals/executive-summary-hcls-toolkit-positioning.md
- docs/proposals/repository-transformation-roadmap.md
- docs/proposals/decision-log-and-rationale.md

## Test plan

- [ ] Review executive summary for clarity and positioning accuracy
- [ ] Review roadmap for feasibility of effort estimates and phasing
- [ ] Validate decision log captures the key architectural choices correctly
- [ ] Confirm alignment with ongoing v1-to-v2 migration project
- [ ] Share with stakeholders for feedback