### PR TITLE
fix(biomni-gateway): support global inference profiles and fix Converse call

### DIFF
--- a/agents_catalog/28-Research-agent-biomni-gateway-tools/prerequisite/infrastructure.yaml
+++ b/agents_catalog/28-Research-agent-biomni-gateway-tools/prerequisite/infrastructure.yaml
@@ -123,8 +123,9 @@ Resources:
                   - bedrock:InvokeModel
                   - bedrock:InvokeModelWithResponseStream
                 Resource:
-                  - !Sub arn:aws:bedrock:${AWS::Region}::foundation-model/*
+                  - !Sub arn:aws:bedrock:*::foundation-model/*
                   - !Sub arn:aws:bedrock:${AWS::Region}:${AWS::AccountId}:inference-profile/*
+                  - !Sub arn:aws:bedrock:*:${AWS::AccountId}:inference-profile/*
               - Sid: SSMGetparam
                 Effect: Allow
                 Action:
@@ -222,8 +223,9 @@ Resources:
                   - bedrock:InvokeModel
                   - bedrock:InvokeModelWithResponseStream
                 Resource:
-                  - !Sub arn:aws:bedrock:${AWS::Region}::foundation-model/*
+                  - !Sub arn:aws:bedrock:*::foundation-model/*
                   - !Sub arn:aws:bedrock:${AWS::Region}:${AWS::AccountId}:inference-profile/*
+                  - !Sub arn:aws:bedrock:*:${AWS::AccountId}:inference-profile/*
       AssumeRolePolicyDocument:
         Version: "2012-10-17"
         Statement:
@@ -248,8 +250,9 @@ Resources:
                   - bedrock:InvokeModel
                   - bedrock:InvokeModelWithResponseStream
                 Resource:
-                  - !Sub arn:aws:bedrock:${AWS::Region}::foundation-model/*
+                  - !Sub arn:aws:bedrock:*::foundation-model/*
                   - !Sub arn:aws:bedrock:${AWS::Region}:${AWS::AccountId}:inference-profile/*
+                  - !Sub arn:aws:bedrock:*:${AWS::AccountId}:inference-profile/*
       AssumeRolePolicyDocument:
         Version: "2012-10-17"
         Statement:

--- a/agents_catalog/28-Research-agent-biomni-gateway-tools/prerequisite/lambda-database/python/database.py
+++ b/agents_catalog/28-Research-agent-biomni-gateway-tools/prerequisite/lambda-database/python/database.py
@@ -48,6 +48,8 @@ def invoke_bedrock_model(
 ):
     """Invoke Bedrock model using Converse API."""
     try:
+        # Note: newer Claude models (e.g. Sonnet 4.6) reject specifying both
+        # temperature and topP in a single Converse call. Send only temperature.
         response = client.converse(
             modelId=model_id,
             system=[{"text": system_prompt}],
@@ -55,7 +57,6 @@ def invoke_bedrock_model(
             inferenceConfig={
                 "temperature": temperature,
                 "maxTokens": max_tokens,
-                "topP": top_p,
             },
         )
         print("response is")


### PR DESCRIPTION
## Summary

Two fixes to the Biomni Research Tools AgentCore Gateway (`agents_catalog/28-Research-agent-biomni-gateway-tools`) that prevented the database/literature tools from invoking Bedrock.

### 1. Bedrock IAM permissions for global inference profiles
The database and literature Lambda roles granted `bedrock:InvokeModel` only on region-scoped foundation-model ARNs (`arn:aws:bedrock:${AWS::Region}::foundation-model/*`). Global inference profiles such as `global.anthropic.claude-sonnet-4-6` resolve to **region-less** foundation-model ARNs (`arn:aws:bedrock:::foundation-model/...`), so calls failed with:

```
AccessDeniedException ... not authorized to perform: bedrock:InvokeModel on
resource: arn:aws:bedrock:::foundation-model/anthropic.claude-sonnet-4-6
```

Broadened the resource to cross-region foundation-model and inference-profile ARNs in all three roles.

### 2. Converse inferenceConfig compatibility
`database.py` sent both `temperature` and `topP` in the Converse `inferenceConfig`. Newer Claude models (e.g. Sonnet 4.6) reject specifying both (`temperature and top_p cannot both be specified for this model`). Now sends only `temperature`.

## Testing
Deployed the full stack to a test account and ran an end-to-end query through the gateway MCP endpoint:

- `query_uniprot` ("human insulin protein, return the UniProt accession ID") -> returned `P01308` (correct)
- `tools/list` over MCP returns the full tool set + semantic search

## Notes
- No credentials, account IDs, or demo-specific values in the diff — only the IAM resource scope and the inferenceConfig change.